### PR TITLE
chore: added styles to the grid cells and grid itself

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,12 +43,11 @@
 
 .container {
   display: grid;
-  width: 500px;
-  height: 500px;
+  width: 80vw;
+  height: 80vw;
 }
-
 .grid-item {
-  padding: 1em;
-  border: 1px solid #ddd;
+  background-color: white;
+  border: 1px solid #000000;
   text-align: center;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import MatrixGrid from "./presenters/matrixGridPresenter";
 function App() {
   return (
     <>
-      <MainPresenter />;
+      <MainPresenter />
       <MatrixGrid />
     </>
   );

--- a/src/presenters/matrixGridPresenter.jsx
+++ b/src/presenters/matrixGridPresenter.jsx
@@ -8,6 +8,7 @@ export default function MatrixGrid(props) {
     container.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
     for (let c = 0; c < rows * cols; c++) {
       let cell = document.createElement("div");
+      cell.classList.add("grid-item");
       cell.style.backgroundColor = "white";
       container.appendChild(cell);
     }


### PR DESCRIPTION
Now grid cells can be styled with App.css class ".grid-item". Border makes it better to recognise each individual cell. Container for the grid is now responsive to the screen width.